### PR TITLE
Officially Support PHP 8.0+ / Add GitHub workflow 

### DIFF
--- a/.github/workflows/project-ci.yml
+++ b/.github/workflows/project-ci.yml
@@ -1,0 +1,34 @@
+name: PHP CI
+
+on:
+  push:
+
+jobs:
+  run:
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest]
+        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+      fail-fast: false
+    name: PHP ${{ matrix.php-versions }} Test
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-versions }}
+        tools: composer:v2.2, phplint, phpcs, dancryer/php-docblock-checker
+    - name: Install Composer dependencies
+      shell: bash
+      run: composer update --no-interaction --no-progress --prefer-dist --optimize-autoloader
+    - name: Run PHPLint
+      shell: bash
+      run: phplint
+    - name: Run PHP_CodeSniffer
+      shell: bash
+      run: phpcs
+    - name: Run PHP DocBlock Checker
+      shell: bash
+      run: phpdoccheck

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<ruleset name="JPI">
+    <file>src</file>
+    <rule ref="vendor/jpi/codestyles/codesniffer.config.xml" />
+
+    <arg name="basepath" value="." />
+    <arg name="extensions" value="php" />
+    <arg name="colors" />
+
+    <arg value="p" />
+</ruleset>

--- a/.phplint.yml
+++ b/.phplint.yml
@@ -1,0 +1,2 @@
+exclude:
+  - vendor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2022-10-24
+
+### Added
+
+- officially specify support for PHP 8.0+
+- added PHP CI workflow using GitHub actions
+
+### Changed
+
+- fixed docblocks
+
 ## [0.3.0] - 2022-10-15
 
 ### Added
@@ -45,7 +56,8 @@ Initial release.
 
 - added singleton trait
 
-[unreleased]: https://github.com/jahidulpabelislam/utilities/compare/v0.3.0...HEAD
+[unreleased]: https://github.com/jahidulpabelislam/utilities/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/jahidulpabelislam/utilities/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/jahidulpabelislam/utilities/compare/v0.2.3...v0.3.0
 [0.2.3]: https://github.com/jahidulpabelislam/utilities/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/jahidulpabelislam/utilities/compare/v0.2.1...v0.2.2

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
     "require": {
         "php": "^7.1 || ^8.0"
     },
+    "require-dev": {
+        "jpi/codestyles": "^1.0.1"
+    },
     "autoload": {
         "psr-4": {
             "JPI\\Utils\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "utilities"
     ],
     "require": {
-        "php": "^7.1"
+        "php": "^7.1 || ^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpdoccheck.yml
+++ b/phpdoccheck.yml
@@ -1,0 +1,6 @@
+exclude:
+  - vendor/*
+
+options:
+  - no-interaction
+  - fail-on-warnings

--- a/src/Singleton.php
+++ b/src/Singleton.php
@@ -33,5 +33,6 @@ trait Singleton {
      *
      * By default don't allow creating instances of the class outside the getter
      */
-    protected function __construct() {}
+    protected function __construct() {
+    }
 }

--- a/src/Singleton.php
+++ b/src/Singleton.php
@@ -1,5 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
+namespace JPI\Utils;
+
 /**
  * Very simple trait to add to classes that are singleton.
  *
@@ -8,11 +12,6 @@
  * @author Jahidul Pabel Islam <me@jahidulpabelislam.com>
  * @copyright 2012-2022 JPI
  */
-
-declare(strict_types=1);
-
-namespace JPI\Utils;
-
 trait Singleton {
 
     protected static $instance = null;

--- a/src/URL.php
+++ b/src/URL.php
@@ -1,22 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
+namespace JPI\Utils;
+
 /**
  * URL builder & helper methods around URLs.
  *
  * @author Jahidul Pabel Islam <me@jahidulpabelislam.com>
  * @copyright 2012-2022 JPI
  */
-
-declare(strict_types=1);
-
-namespace JPI\Utils;
-
 class URL {
 
     /**
      * Remove the leading slash from passed path (if there is one).
      *
-     * @param $path string
+     * @param string $path
      * @return string
      */
     public static function removeLeadingSlash(string $path): string {
@@ -27,7 +26,7 @@ class URL {
     /**
      * Remove the trailing slash from passed URL (if there is one).
      *
-     * @param $url string
+     * @param string $url
      * @return string
      */
     public static function removeTrailingSlash(string $url): string {
@@ -38,7 +37,7 @@ class URL {
     /**
      * Remove both leading & trailing slashes from passed path (if there is any).
      *
-     * @param $path string
+     * @param string $path
      * @return string
      */
     public static function removeSlashes(string $path): string {
@@ -48,7 +47,7 @@ class URL {
     /**
      * Add a leading slash to passed path (if there isn't one already).
      *
-     * @param $path string
+     * @param string $path
      * @return string
      */
     public static function addLeadingSlash(string $path): string {
@@ -60,7 +59,7 @@ class URL {
     /**
      * Add a trailing slash to passed URL (if there isn't one already).
      *
-     * @param $url string
+     * @param string $url
      * @return string
      */
     public static function addTrailingSlash(string $url): string {
@@ -115,7 +114,7 @@ class URL {
     /**
      * Parse the components out from passed URL string if passed.
      *
-     * @param $url string|null
+     * @param string|null $url
      */
     public function __construct(string $url = null) {
         if (!$url) {
@@ -144,8 +143,8 @@ class URL {
     }
 
     /**
-     * @param $scheme string|null
-     * @return $this
+     * @param string|null $scheme
+     * @return URL
      */
     public function setScheme(string $scheme = null): URL {
         $this->scheme = $scheme;
@@ -160,8 +159,8 @@ class URL {
     }
 
     /**
-     * @param $host string|null
-     * @return $this
+     * @param string|null $host
+     * @return URL
      */
     public function setHost(string $host = null): URL {
         $this->host = $host;
@@ -176,8 +175,8 @@ class URL {
     }
 
     /**
-     * @param $path string|null
-     * @return $this
+     * @param string|null $path
+     * @return URL
      */
     public function setPath(string $path = null): URL {
         $this->path = $path;
@@ -187,8 +186,8 @@ class URL {
     /**
      * Add part(s) to the current path.
      *
-     * @param $path string
-     * @return $this
+     * @param string $path
+     * @return URL
      */
     public function addPath(string $path): URL {
         if (!$this->path) {
@@ -207,8 +206,8 @@ class URL {
     /**
      * Set query parameters.
      *
-     * @param $params array
-     * @return $this
+     * @param array $params
+     * @return URL
      */
     public function setParams(array $params): URL {
         $this->params = $params;
@@ -218,9 +217,9 @@ class URL {
     /**
      * Add/set query parameter.
      *
-     * @param $key string
-     * @param $value string|array
-     * @return $this
+     * @param string $key
+     * @param string|array $value
+     * @return URL
      */
     public function setParam(string $key, $value): URL {
         $this->params[$key] = $value;
@@ -230,8 +229,8 @@ class URL {
     /**
      * Remove a query parameter.
      *
-     * @param $key string
-     * @return $this
+     * @param string $key
+     * @return URL
      */
     public function removeParam(string $key): URL {
         unset($this->params[$key]);
@@ -259,8 +258,8 @@ class URL {
     }
 
     /**
-     * @param $fragment string|null
-     * @return $this
+     * @param string|null $fragment
+     * @return URL
      */
     public function setFragment(string $fragment = null): URL {
         $this->fragment = $fragment;


### PR DESCRIPTION
- set up GitHub workflow actions to run Codesniffer, phplint and docblock checker tests
    - add https://packagist.org/packages/jpi/codestyles as a dev dependency 
- officially specify support PHP 8.0+
- fix docblocks for correct standards