### PR TITLE
Add JsonSerializable to Collection & URL classes

### DIFF
--- a/src/Collection/BaseTrait.php
+++ b/src/Collection/BaseTrait.php
@@ -56,6 +56,10 @@ trait BaseTrait {
         return $this->count();
     }
 
+    public function jsonSerialize(): array {
+        return $this->getItems();
+    }
+
     protected static function getFromItem($item, string|int $key) {
         if (is_array($item)) {
             return $item[$key] ?? null;

--- a/src/CollectionInterface.php
+++ b/src/CollectionInterface.php
@@ -7,12 +7,14 @@ namespace JPI\Utils;
 use ArrayAccess;
 use Countable;
 use IteratorAggregate;
+use JsonSerializable;
 
 interface CollectionInterface extends
     Arrayable,
     ArrayAccess,
     Countable,
-    IteratorAggregate {
+    IteratorAggregate,
+    JsonSerializable {
 
     public function isset(string|int $key): bool;
 

--- a/src/URL.php
+++ b/src/URL.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace JPI\Utils;
 
+use JsonSerializable;
 use Stringable;
 
 /**
  * URL builder & helper methods around URLs.
  */
-class URL implements Stringable {
+class URL implements JsonSerializable, Stringable {
 
     public static function removeLeadingSlash(string $path): string {
         $path = trim($path, " ");
@@ -205,6 +206,10 @@ class URL implements Stringable {
     }
 
     public function __toString(): string {
+        return $this->build();
+    }
+
+    public function jsonSerialize(): string {
         return $this->build();
     }
 }


### PR DESCRIPTION
Will reduce having to manual cast before doing `json_encode` on these objects or things containing these objects.