### PR TITLE
Collection: Trigger an warning if key doesn't exist

### DIFF
--- a/src/Collection/BaseTrait.php
+++ b/src/Collection/BaseTrait.php
@@ -37,6 +37,9 @@ trait BaseTrait {
 
     #[\ReturnTypeWillChange]
     public function offsetGet($key) {
+        if (!$this->isset($key)) {
+            trigger_error("Undefined array key $key", E_USER_WARNING);
+        }
         return $this->get($key);
     }
 


### PR DESCRIPTION
If you use the collection like an normal array, and try to use an key that doesn't exist trigger a warning like normal PHP does.